### PR TITLE
fix(eslint.config.mjs): fix build errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,13 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.config({
+    extends: [("next/core-web-vitals", "next/typescript")],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unused-vars": "warn",
+    },
+  }),
 ];
 
 export default eslintConfig;


### PR DESCRIPTION
build errors occurred because of strict default type rules